### PR TITLE
Use `EntityId::getSerialization()` instead of `serialize()`

### DIFF
--- a/src/UseCases/ItemPropertiesToStrings/ItemPropertiesToStrings.php
+++ b/src/UseCases/ItemPropertiesToStrings/ItemPropertiesToStrings.php
@@ -70,7 +70,7 @@ class ItemPropertiesToStrings {
 		}
 
 		if ( $property->getDataTypeId() !== self::ITEM_PROPERTY_TYPE ) {
-			throw new \RuntimeException( $propertyId->serialize() . ' has incorrect data type "' . $property->getDataTypeId() . '"' );
+			throw new \RuntimeException( $propertyId->getSerialization() . ' has incorrect data type "' . $property->getDataTypeId() . '"' );
 		}
 
 		$this->presenter->presentChangingPropertyType( $propertyId, $property->getDataTypeId(), self::STRING_PROPERTY_TYPE );


### PR DESCRIPTION
Bug: [T345856](https://phabricator.wikimedia.org/T345856)

----

Should be okay to merge regardless of supported MW/WB version (`getSerialization()` has existed pretty much always), but becomes more important for MW 1.41, since we’re going to remove `serialize()`.